### PR TITLE
v1.0.0 release

### DIFF
--- a/director.go
+++ b/director.go
@@ -15,7 +15,7 @@ func (e *Director) PushState(scene IScene) error {
 }
 
 func (e *Director) PopState() error {
-	err := e.PeekState().Popped(e)
+	err := e.PeekState().(IScene).Popped(e)
 	if err != nil {
 		return err
 	}
@@ -33,11 +33,11 @@ func (e *Director) ChangeState(scene IScene) error {
 	return e.PushState(scene)
 }
 
-func (e *Director) PeekState() IScene {
+func (e *Director) PeekState() interface{} {
 	if e.scenes.Len() == 0 {
 		return nil
 	}
-	return e.scenes.Peek().(IScene)
+	return e.scenes.Peek()
 }
 
 func NewDirector(initialScene IScene) *Director {

--- a/scene.go
+++ b/scene.go
@@ -5,7 +5,6 @@ type IScene interface {
 	Popped(director *Director) error // Executed when the state is popped off of the StateMachine stack
 	Tick(dt float32)
 	GetName() string
-	ShouldQuit() bool
 }
 
 type Scene struct {
@@ -28,9 +27,4 @@ func (s *Scene) Tick(dt float32) {
 
 func (s *Scene) GetName() string {
 	return s.Name
-}
-
-// ShouldQuit is deprecated, use ShouldQuit on Director instead
-func (s *Scene) ShouldQuit() bool {
-	return s.Director.ShouldQuit
 }


### PR DESCRIPTION
This removes a deprecated function and changes the return value of `Director.PeekState` to be an interface. This is because I began using this package in an application that needed to extend `IScene` with other methods and the previous implementation meant that was impossible.