### PR TITLE
v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,24 @@
 <a href="https://pkg.go.dev/github.com/go-rogue/scenes?tab=doc"><img src="https://godoc.org/github.com/golang/gddo?status.svg" alt="GoDoc"></a>
 
 This package provides a Scene interface and Scene Director struct for use in game dev. The stack it uses is thread safe.
+
+## Usage
+
+The Scene Director operates on structs implementing `IScene` however this interface intentionally doesn't provide an `update` or `draw` methods. That is up to you to implement in your extension to `IScene`.
+
+For example you might have your own `Scene` interface such as:
+
+```go
+type Scene interface {
+    scenes.IScene
+    Draw()
+    HandleEvent(ev tcell.Event) bool
+}
+```
+
+You would then cast the return of `PeekState()` to your required interface like so:
+
+```go
+scene := director.PeekState().(Scene)
+scene.Draw()
+```

--- a/scene.go
+++ b/scene.go
@@ -3,7 +3,6 @@ package scenes
 type IScene interface {
 	Pushed(director *Director) error // Executed when the state is pushed onto the StateMachine stack
 	Popped(director *Director) error // Executed when the state is popped off of the StateMachine stack
-	Tick(dt float32)
 	GetName() string
 }
 
@@ -19,10 +18,6 @@ func (s *Scene) Pushed(director *Director) error {
 
 func (s *Scene) Popped(director *Director) error {
 	return nil
-}
-
-func (s *Scene) Tick(dt float32) {
-	// abstract
 }
 
 func (s *Scene) GetName() string {


### PR DESCRIPTION
This adds a short description on usage plus removes the `Tick` method from `IScene`. With `PeekState` now returning an `interface{}`, users of this package can cast that to their own implementations so long as that also qucks like `IScene`. This package should only care about and deal with things that are shaped like `IScene`.